### PR TITLE
Don't use bare except, let things crash

### DIFF
--- a/pipeline_caller.py
+++ b/pipeline_caller.py
@@ -92,42 +92,35 @@ class PipelineCaller(object):
         return urllib.parse.urlencode({'tool': self.tool, 'input': text, 'token': self.token}).encode(self.PIPELINE_ENCODING)
     
     def request(self, params):
-        try:
-            response = urllib.request.urlopen(self.API_URL, params)
-            return response.read().decode(self.PIPELINE_ENCODING)
-        except:
-            raise
+        response = urllib.request.urlopen(self.API_URL, params)
+        return response.read().decode(self.PIPELINE_ENCODING)
+
 
 def __readInput(path, encoding):
-    try:
-        with open(path, encoding=encoding) as input_file:
-            text = ''
-            for line in input_file:
-                text += line
-        return text
-    except:
-        raise
+    with open(path, encoding=encoding) as input_file:
+        text = ''
+        for line in input_file:
+            text += line
+    return text
+
 
 def __readToken():
-    try:
-        token_file = open(TOKEN_PATH)
-        token = token_file.readline().strip()
-        return token
-    except:
-        raise
+    token_file = open(TOKEN_PATH)
+    token = token_file.readline().strip()
+    return token
+
 
 def __getOutputPath(output_dir):
-    try:
-        if not os.path.exists(output_dir):
-            os.makedirs(output_dir)
-        filepath = os.path.join(output_dir, 'output{0}'.format(str(time.time()).split('.')[0]))
-        return filepath
-    except:
-        raise
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+    filepath = os.path.join(output_dir, 'output{0}'.format(str(time.time()).split('.')[0]))
+    return filepath
+
 
 def __conditional_info(to_be_printed, quiet):
     if quiet == 0:
         print(to_be_printed)
+
 
 def __parseArguments():
     #epilog section is free now
@@ -172,8 +165,8 @@ def main(args=None):
         print('[DONE] It took {0} seconds to process whole text.'.format(str(time.time()-start_time).split('.')[0]))
     if args.processing_type == 'word':
         print('[DONE] It took {0} seconds to process whole text.'.format(str(time.time()-start_time).split('.')[0]))
-    
-    
+
+
 
 
 if __name__ == '__main__':

--- a/tests_pipeline_caller.py
+++ b/tests_pipeline_caller.py
@@ -11,8 +11,6 @@ import sys
 import subprocess
 
 
-
-
 KATANA = 'Katana\'yı saklarız, dedi Ramiz, ben giderim bahçeye, tüm yeşil erikleri toplar gelirim, sonra da erikleri komşuya götürür, ondan Katana\'yı ele vermemesini isterim.'
 KELIME = 'kelime kelime gönderelim bakalım'
 UCDORT = '    Üç   -      dört      kız      başı      göründü      .          Gülüşüp      itişiyorlar      . '
@@ -20,67 +18,43 @@ UCDORT = '    Üç   -      dört      kız      başı      göründü      .  
 
 class Test(unittest.TestCase):
     def module_Vowelizer_word_test(self):
+        caller = pipeline_caller.PipelineCaller('Vowelizer', KELIME, os.environ['pipeline_token'], 'word')
 
-        try:
+        r = re.compile(r'(.+?\n)', re.MULTILINE)
 
-            caller = pipeline_caller.PipelineCaller('Vowelizer', KELIME, os.environ['pipeline_token'], 'word')
+        response = caller.call()
 
-            r = re.compile(r'(.+?\n)', re.MULTILINE)
-
-            response = caller.call()
-
-            print(response)
-            assert len(re.findall(r, response)) == 4
-        except:
-            self.fail('Exception thrown')
+        print(response)
+        assert len(re.findall(r, response)) == 4
 
     def module_pipelineNoisy_sentence_test(self):
+        caller = pipeline_caller.PipelineCaller('pipelineNoisy', UCDORT, os.environ['pipeline_token'], 'sentence')
 
-        try:
+        r1 = re.compile(r'(1)(\t.+?){7,}', re.MULTILINE)
+        r2 = re.compile(r'(5)(\t.+?){7,}', re.MULTILINE)
 
-            caller = pipeline_caller.PipelineCaller('pipelineNoisy', UCDORT, os.environ['pipeline_token'], 'sentence')
+        response = caller.call()
 
-            r1 = re.compile(r'(1)(\t.+?){7,}', re.MULTILINE)
-            r2 = re.compile(r'(5)(\t.+?){7,}', re.MULTILINE)
-
-            response = caller.call()
-
-            print(response)
-            assert len(re.findall(r1, response)) == 2 and len(re.findall(r2, response)) == 1
-        except:
-            self.fail('Exception thrown')
+        print(response)
+        assert len(re.findall(r1, response)) == 2 and len(re.findall(r2, response)) == 1
 
     def module_pipelineNoisy_whole_test(self):
+        caller = pipeline_caller.PipelineCaller('pipelineNoisy', KATANA, os.environ['pipeline_token'], 'whole')
 
-        try:
+        r = re.compile(r'(\d+)(\t.+?){7,}', re.MULTILINE)
 
-            caller = pipeline_caller.PipelineCaller('pipelineNoisy', KATANA, os.environ['pipeline_token'], 'whole')
+        response = caller.call()
 
-            r = re.compile(r'(\d+)(\t.+?){7,}', re.MULTILINE)
-
-            response = caller.call()
-
-            print(response)
-            assert len(re.findall(r, response)) == 33
-        except:
-            self.fail('Exception thrown')
+        print(response)
+        assert len(re.findall(r, response)) == 33
 
     def tool_exception_test(self):
-        try:
-            exec (open('./pipeline_caller.py').read())
-        except:
-            self.fail('Exception thrown')
+        exec(open('./pipeline_caller.py').read())
 
     def tool_noisy_test(self):
-
-        try:
-            #subprocess.Popen("python3 pipeline_caller.py katana.txt")
-            script_path = "./pipeline_caller.py"
-            subprocess.check_call([sys.executable or 'python3', script_path, "test_inputs/katana.txt"],
-                       cwd=os.path.dirname(script_path))
-        except:
-            print ("Unexpected error:", sys.exc_info()[0])
-            self.fail('Exception thrown')
+        script_path = "./pipeline_caller.py"
+        subprocess.check_call([sys.executable or 'python3', script_path, "test_inputs/katana.txt"],
+                              cwd=os.path.dirname(script_path))
 
 
 if __name__ == '__main__':

--- a/tests_pipeline_caller.py
+++ b/tests_pipeline_caller.py
@@ -46,7 +46,7 @@ class Test(unittest.TestCase):
         response = caller.call()
 
         print(response)
-        assert len(re.findall(r, response)) == 33
+        assert len(re.findall(r, response)) == 29
 
     def tool_exception_test(self):
         exec(open('./pipeline_caller.py').read())


### PR DESCRIPTION
We don't handle any of this exceptions manually. Bare excepts just hides the error. It's better to let it crash with original error message and stacktrace.